### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-#CollectionView Layouts Demo
+# CollectionView Layouts Demo
 
 Sample iOS app to demonstrate how to customize CollectionViewFlowLayout and CollectionViewLayout. This app accompanied my talk ["Living off the Grid with UICollectionViews"](https://speakerdeck.com/jaythrash/living-off-the-grid-with-uicollectionviews) at 360iDev 2013.
 
-##BookShelf Layout
+## BookShelf Layout
 Example of a customized UICollectionViewFlowLayout which uses Supplimentary Views (Section Headers) and Decoration Views (the book shelves)
 
 ![](https://raw.github.com/jaythrash/CollectionViewLayoutDemo/master/BookShelfLayout.png)
 
-##Passbook Layout
+## Passbook Layout
 Example of a customized UICollectionViewLayout based on the iOS Passbook.app. CollectionView cells are displayed as a stacked deck of "cards" and tapping a card will shuffle it to the top of the screen while simultaneously moving the other cards to a stack at the bottom of the screen. 
 
 ![](https://raw.github.com/jaythrash/CollectionViewLayoutDemo/master/Passbook.gif)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
